### PR TITLE
Add admin panel for song management

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 ﻿import React, { useState, useRef, useEffect } from 'react';
 import AuthForms from './components/auth';
 import { HomePage } from './components/HomePage';
+import AdminPanel from './components/AdminPanel';
 
 
 
@@ -35,6 +36,7 @@ const LoginScreen = ({ onLogin }) => {
 
 export default function App() {
     const [user, setUser] = useState(null);
+    const [view, setView] = useState('home');
 
     useEffect(() => {
         function handleLoggedInUser(){
@@ -49,16 +51,24 @@ export default function App() {
     const handleLogin = (newUser) => {
         sessionStorage.setItem('melody-user', JSON.stringify(newUser));
         setUser(newUser);
+        setView('home');
     };
 
     const handleLogout = () => {
         sessionStorage.removeItem('melody-user');
         setUser(null);
+        setView('home');
     };
 
     return (
         <div className="bg-gray-900 text-white min-h-screen font-sans">
-            {!user ? <LoginScreen onLogin={handleLogin} /> : <HomePage user={user} onLogout={handleLogout} />}
+            {!user && <LoginScreen onLogin={handleLogin} />}
+            {user && view === 'home' && (
+                <HomePage user={user} onLogout={handleLogout} onManageSongs={() => setView('admin')} />
+            )}
+            {user && view === 'admin' && (
+                <AdminPanel onBack={() => setView('home')} />
+            )}
         </div>
     );
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/Melody Music/i)).toBeInTheDocument();
 });

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { loadCustomSongs, saveCustomSongs } from './data';
+
+const emptySong = { id: '', title: '', artist: '', genre: '', moods: '', url: '', cover: '' };
+
+export default function AdminPanel({ onBack }) {
+  const [songs, setSongs] = useState(loadCustomSongs());
+  const [form, setForm] = useState(emptySong);
+
+  useEffect(() => {
+    saveCustomSongs(songs);
+    window.dispatchEvent(new Event('storage')); // notify other tabs/components
+  }, [songs]);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const addSong = (e) => {
+    e.preventDefault();
+    if (!form.id || !form.title || !form.url) return;
+    const newSong = {
+      ...form,
+      moods: form.moods.split(',').map(m => m.trim()).filter(Boolean)
+    };
+    setSongs([...songs, newSong]);
+    setForm(emptySong);
+  };
+
+  const removeSong = (index) => {
+    const updated = songs.filter((_, i) => i !== index);
+    setSongs(updated);
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <h2 className="text-2xl font-bold">Admin Panel</h2>
+      <button onClick={onBack} className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded">
+        Back
+      </button>
+
+      <form onSubmit={addSong} className="space-y-2 max-w-md mt-4">
+        {['id','title','artist','genre','moods','url','cover'].map(field => (
+          <input
+            key={field}
+            name={field}
+            value={form[field]}
+            onChange={handleChange}
+            placeholder={field.charAt(0).toUpperCase() + field.slice(1)}
+            className="w-full px-3 py-2 bg-gray-800 rounded"
+          />
+        ))}
+        <button type="submit" className="bg-cyan-500 hover:bg-cyan-400 px-4 py-2 rounded text-gray-900 font-semibold">
+          Add Song
+        </button>
+      </form>
+
+      <div>
+        <h3 className="text-xl font-semibold mb-2">Custom Songs</h3>
+        <ul className="space-y-2">
+          {songs.map((s, idx) => (
+            <li key={s.id} className="flex justify-between items-center bg-gray-800 p-2 rounded">
+              <span>{s.title} - {s.artist}</span>
+              <button onClick={() => removeSong(idx)} className="bg-red-600 hover:bg-red-500 text-white px-2 py-1 rounded">
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -1,4 +1,4 @@
-import { allSongs } from "./data";
+import { getAllSongs } from "./data";
 import { Player } from "./helpers";
 import  MoodDetector  from "./MoodDetector";
 import React, { useState, useEffect, useRef } from "react";
@@ -7,7 +7,8 @@ import { SongCard } from "./helpers";
 // --- Helper Components (Icons) ---
 const LogoutIcon = () => <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /><polyline points="16 17 21 12 16 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /><line x1="21" y1="12" x2="9" y2="12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>;
 
-export const HomePage = ({ user, onLogout }) => {
+export const HomePage = ({ user, onLogout, onManageSongs }) => {
+    const [allSongs, setAllSongs] = useState(getAllSongs());
     const [activeMood, setActiveMood] = useState(null);
     const [currentSong, setCurrentSong] = useState(null);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -24,6 +25,12 @@ export const HomePage = ({ user, onLogout }) => {
     const audioRef = useRef(null);
 
     const getFilenameFromUrl = (url) => url.split('/').pop().replace(/%20/g, ' ');
+
+    useEffect(() => {
+        const refreshSongs = () => setAllSongs(getAllSongs());
+        window.addEventListener('storage', refreshSongs);
+        return () => window.removeEventListener('storage', refreshSongs);
+    }, []);
  
     // Effect to load the cosine similarity data
     useEffect(() => {
@@ -214,6 +221,14 @@ export const HomePage = ({ user, onLogout }) => {
                         <span className="text-gray-400">Welcome, {user.username}!😁</span>
                         <p className="text-sm text-cyan-400">Your vibe decides your tribe 🤞😉</p>
                     </div>
+                    {onManageSongs && user.username === 'admin' && (
+                        <button
+                            onClick={onManageSongs}
+                            className="bg-cyan-600 hover:bg-cyan-500 text-white font-bold py-2 px-4 rounded transition-all duration-300"
+                        >
+                            Admin Panel
+                        </button>
+                    )}
                     <button
                         onClick={onLogout}
                         className="inline-flex items-center gap-2 bg-red-600 hover:bg-red-500 text-white font-bold py-2 px-4 rounded transition-all duration-300 tooltip"

--- a/frontend/src/components/data.js
+++ b/frontend/src/components/data.js
@@ -1,7 +1,7 @@
 
 
 // --- Expanded Song Library ---
-export const allSongs = [
+export const defaultSongs = [
     // Happy & Energetic
     /*
     { id: "S001", title: "Walking on Sunshine", artist: "The Good Vibes", genre: "Pop", moods: ['happy', 'energetic', 'upbeat'], url: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3", cover: "https://placehold.co/300x300/f9d423/000000?text=Sunshine" },
@@ -261,6 +261,23 @@ export const allSongs = [
         cover: "https://placehold.co/300x300/f1c40f/000000?text=Funk"
     }
 
-
     // More variety
-    ];
+];
+
+export const loadCustomSongs = () => {
+    const data = localStorage.getItem('melody-custom-songs');
+    if (!data) return [];
+    try {
+        return JSON.parse(data);
+    } catch {
+        return [];
+    }
+};
+
+export const saveCustomSongs = (songs) => {
+    localStorage.setItem('melody-custom-songs', JSON.stringify(songs));
+};
+
+export const getAllSongs = () => {
+    return [...defaultSongs, ...loadCustomSongs()];
+};


### PR DESCRIPTION
## Summary
- add AdminPanel component so admins can manage songs
- allow HomePage to refresh song list from local storage
- expose helper functions to load/save custom songs
- switch view between home and admin in App
- update React test for new UI

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68821f32994c8321a1cf52a73e892653